### PR TITLE
Android - Properly filled react pan events

### DIFF
--- a/android/src/main/java/com/rnds/DirectedScrollView.java
+++ b/android/src/main/java/com/rnds/DirectedScrollView.java
@@ -69,7 +69,7 @@ public class DirectedScrollView extends ReactViewGroup {
 
   @Override
   public boolean onInterceptTouchEvent(final MotionEvent motionEvent) {
-    emitScrollEvent(ScrollEventType.STAR_DRAG, 0, 0);
+    emitScrollEvent(ScrollEventType.START_DRAG, 0, 0);
 
     int action = motionEvent.getAction();
     if (action == MotionEvent.ACTION_UP | action == MotionEvent.ACTION_CANCEL) {

--- a/android/src/main/java/com/rnds/DirectedScrollView.java
+++ b/android/src/main/java/com/rnds/DirectedScrollView.java
@@ -69,7 +69,7 @@ public class DirectedScrollView extends ReactViewGroup {
 
   @Override
   public boolean onInterceptTouchEvent(final MotionEvent motionEvent) {
-    emitScrollEvent(ScrollEventType.START_DRAG, 0, 0);
+    emitScrollEvent(ScrollEventType.BEGIN_DRAG, 0, 0);
 
     int action = motionEvent.getAction();
     if (action == MotionEvent.ACTION_UP | action == MotionEvent.ACTION_CANCEL) {


### PR DESCRIPTION
All in the title, pretty straightforward...

Now, panhandler events will be filled with `contentOffset` `x` and `y` values.

Beware, when `clamp` is enabled, the offsets returned by the event can be out of the boundary of the content size !

