### PR TITLE
Invalid single quote fix

### DIFF
--- a/react-native-directed-scrollview.podspec
+++ b/react-native-directed-scrollview.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '7.0'
 
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
-  s.source_files   = 'ios/DirectedScrollView/*.{h,m}’
+  s.source_files   = 'ios/DirectedScrollView/*.{h,m}'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
When running `pod install` it fails with the following: 

```
[!] Failed to load 'react-native-directed-scrollview' podspec: 
[!] Invalid `react-native-directed-scrollview.podspec` file: syntax error, unexpected tCONSTANT, expecting keyword_end
  s.dependency 'React'
                     ^
/Users/andrewdurber/code/testapp/node_modules/react-native-directed-scrollview/react-native-directed-scrollview.podspec:21: unterminated string meets end of file
/Users/andrewdurber/code/testapp/node_modules/react-native-directed-scrollview/react-native-directed-scrollview.podspec:21: syntax error, unexpected end-of-input, expecting keyword_end.
```

Which was caused by the single quote being: `’` instead of `'`