### PR TITLE
Fix sdkVersion warning from gradle v3+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,10 +126,10 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-directed-scrollview')
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(':react-native-directed-scrollview')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:23.0.1"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK


### PR DESCRIPTION
Fix sdk warning since using gradle v3+ it support only sdk version `26.0.2` onward.
