### PR TITLE
Fix android alwaysBounce behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following props are supported:
 | `maximumZoomScale` | `1.0` | How far the content can zoom in. |
 | `bounces` | `true` | Whether content bounces at the limits when scrolling. |
 | `bouncesZoom` | `true` | Whether content bounces at the limits when zooming. |
-| `alwaysBounceHorizontal` | `true` | When `bounces` is enabled, content will bounce horizontally. |
-| `alwaysBounceVertical` | `true` | When `bounces` is enabled, content will bounce vertically. |
+| `alwaysBounceHorizontal` | `false` | When `bounces` is enabled, content will bounce horizontally even if the content is smaller than the bounds of the scroll view. |
+| `alwaysBounceVertical` | `false` | When `bounces` is enabled, content will bounce vertically even if the content is smaller than the bounds of the scroll view.. |
 | **ios** `showsVerticalScrollIndicator` | `true` | Whether vertical scroll bars are visible. |
 | **ios** `showsHorizontalScrollIndicator` | `true` | Whether horizontal scroll bars are visible. |
 
@@ -54,13 +54,13 @@ export default class Example extends Component {
         style={styles.container}
       >
         <ScrollViewChild scrollDirection={'both'}>
-          // multi-directional scrolling content here...      
+          // multi-directional scrolling content here...
         </ScrollViewChild>
         <ScrollViewChild scrollDirection={'vertical'}>
-          // vertically scrolling content here...      
+          // vertically scrolling content here...
         </ScrollViewChild>
         <ScrollViewChild scrollDirection={'horizontal'}>
-          // horizontally scrolling content here...      
+          // horizontally scrolling content here...
         </ScrollViewChild>
       </ScrollView>
     );

--- a/android/src/main/java/com/rnds/DirectedScrollView.java
+++ b/android/src/main/java/com/rnds/DirectedScrollView.java
@@ -31,8 +31,8 @@ public class DirectedScrollView extends ReactViewGroup {
   private float minimumZoomScale = 1.0f;
   private float maximumZoomScale = 1.0f;
   private boolean bounces = true;
-  private boolean alwaysBounceVertical = true;
-  private boolean alwaysBounceHorizontal = true;
+  private boolean alwaysBounceVertical = false;
+  private boolean alwaysBounceHorizontal = false;
   private boolean bouncesZoom = true;
   private boolean scrollEnabled = true;
   private boolean pinchGestureEnabled = true;
@@ -214,7 +214,7 @@ public class DirectedScrollView extends ReactViewGroup {
     scrollY = startScrollY + deltaY;
 
     if (bounces) {
-      clampAndTranslateChildren(false, !this.alwaysBounceVertical, !this.alwaysBounceHorizontal);
+      clampAndTranslateChildren(false, getMaxScrollY() <= 0 && !alwaysBounceVertical, getMaxScrollX() <= 0 && !alwaysBounceHorizontal);
     } else {
       clampAndTranslateChildren(false);
     }

--- a/android/src/main/java/com/rnds/DirectedScrollViewManager.java
+++ b/android/src/main/java/com/rnds/DirectedScrollViewManager.java
@@ -75,12 +75,12 @@ class DirectedScrollViewManager extends ViewGroupManager<DirectedScrollView> {
     view.setBouncesZoom(bouncesZoom);
   }
 
-  @ReactProp(name = "alwaysBounceHorizontal", defaultBoolean = true)
+  @ReactProp(name = "alwaysBounceHorizontal", defaultBoolean = false)
   public void setAlwaysBounceHorizontal(DirectedScrollView view, @Nullable boolean alwaysBounceHorizontal) {
     view.setAlwaysBounceHorizontal(alwaysBounceHorizontal);
   }
 
-  @ReactProp(name = "alwaysBounceVertical", defaultBoolean = true)
+  @ReactProp(name = "alwaysBounceVertical", defaultBoolean = false)
   public void setAlwaysBounceVertical(DirectedScrollView view, @Nullable boolean alwaysBounceVertical) {
     view.setAlwaysBounceVertical(alwaysBounceVertical);
   }


### PR DESCRIPTION
From PR #24

I implemented `alwaysBounceVertical` / `alwaysBounceHorizontal` incorrectly on android.
My first imple : Disable bounce if those props are set to `false`.

Correct imple according to the doc (https://facebook.github.io/react-native/docs/scrollview.html#alwaysbouncevertical) : 

> When true, the scroll view bounces vertically when it reaches the end even if the content is smaller than the scroll view itself. The default value is false when horizontal={true} and true otherwise.

Now, the above props will enable bouncing even if the content is smaller than the container if set to true (default to false)


