### PR TITLE
Android: compile - not implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,53 @@ The following methods are supported:
 - `npm install react-native-directed-scrollview --save`
 - `react-native link` (or `rnpm link`)
 
+### Manual Linking (Android)
+Follow these steps if automatic linking (`react-native link`) failed.
+
+1. Include this module in `android/settings.gradle`:
+
+   ```
+   ...
+   include ':react-native-directed-scrollview' // Add this
+   project(':react-native-directed-scrollview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-directed-scrollview/android') // Add this
+
+   ...
+   include ':app'
+   ```
+
+2. In `android/app/build.gradle`, add the dependency to your app build:
+
+   ```
+   dependencies {
+       ...
+       compile project(':react-native-directed-scrollview') // Add this
+   }
+   ```
+
+3. Import and add package, in `android/app/src/main/.../MainApplication.java`:
+
+   ```java
+   ...
+   import android.app.Application;
+   ...
+
+   import com.rnds.DirectedScrollViewPackage; // Add new import
+
+   ...
+
+   public class MainApplication extends Application implements ReactApplication {
+     ...
+     @Override
+     protected List<ReactPackage> getPackages() {
+       return Arrays.<ReactPackage>asList(
+         new MainReactPackage(),
+         ...
+         new DirectedScrollViewPackage() // Add the package here
+       );
+     }
+   }
+   ```
+
 ## Usage
 
 To work properly this component requires that a fixed-size content container be specified through the **contentContainerStyle** prop.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
On Android, without this change we get this buidl fail error on build attempts:

```
PS C:\Users\Mercurius\Documents\GitHub\trustedplatform_android> react-native run-android
Scanning folders for symlinks in C:\Users\Mercurius\Documents\GitHub\trustedplatform_android\node_modules
(102ms)
Starting JS server...
Building and installing the app on the device (cd android && gradlew.bat installDebug)...
Incremental java compilation is an incubating feature.

FAILURE: Build failed with an exception.

* Where:
Build file 'C:\Users\Mercurius\Documents\GitHub\trustedplatform_android\node_modules\react-native-directed-scrollview\android\build.gradle' line: 22

* What went wrong:
A problem occurred evaluating project ':react-native-directed-scrollview'.
> Could not find method implementation() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 1 mins 57.92 secs
Could not install the app on the device, read the error above for details.
Make sure you have an Android emulator running or a device connected and have
set up your Android development environment:
https://facebook.github.io/react-native/docs/android-setup.html
```