### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Fix for Android for users using older gradle. RN projects start with older gradle. Gradle 3 I think mayyyy come to default project but not yet.