### PR TITLE
updates to ScrollEventType for RN 0.57.3

### DIFF
--- a/android/src/main/java/com/rnds/DirectedScrollViewManager.java
+++ b/android/src/main/java/com/rnds/DirectedScrollViewManager.java
@@ -61,11 +61,11 @@ class DirectedScrollViewManager extends ViewGroupManager<DirectedScrollView> {
 
   public static Map createExportedCustomDirectEventTypeConstants() {
     return MapBuilder.builder()
-        .put(ScrollEventType.SCROLL.getJSEventName(), MapBuilder.of("registrationName", "onScroll"))
-        .put(ScrollEventType.BEGIN_DRAG.getJSEventName(), MapBuilder.of("registrationName", "onScrollBeginDrag"))
-        .put(ScrollEventType.END_DRAG.getJSEventName(), MapBuilder.of("registrationName", "onScrollEndDrag"))
-        .put(ScrollEventType.MOMENTUM_BEGIN.getJSEventName(), MapBuilder.of("registrationName", "onMomentumScrollBegin"))
-        .put(ScrollEventType.MOMENTUM_END.getJSEventName(), MapBuilder.of("registrationName", "onMomentumScrollEnd"))
+        .put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"))
+        .put(ScrollEventType.getJSEventName(ScrollEventType.BEGIN_DRAG), MapBuilder.of("registrationName", "onScrollBeginDrag"))
+        .put(ScrollEventType.getJSEventName(ScrollEventType.END_DRAG), MapBuilder.of("registrationName", "onScrollEndDrag"))
+        .put(ScrollEventType.getJSEventName(ScrollEventType.MOMENTUM_BEGIN), MapBuilder.of("registrationName", "onMomentumScrollBegin"))
+        .put(ScrollEventType.getJSEventName(ScrollEventType.MOMENTUM_END), MapBuilder.of("registrationName", "onMomentumScrollEnd"))
         .build();
   }
 


### PR DESCRIPTION
There isn't a way to maintain backwards compatibility (as far as I know), because the java compiler will complain about the parameter differences. This is a really crappy way to change the code on the RN side, so I guess this library will require a major version bump and notices that version 2 isn't compatible with < 0.57.3. Addresses #47 