### PR TITLE
Add create-react-class dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "vertical",
     "direction"
   ],
+  "dependencies": {
+    "create-react-class": "^15.6.3"
+  },
   "peerDependencies": {
     "react-native": ">=0.56.0"
   },


### PR DESCRIPTION
[create-react-class](https://www.npmjs.com/package/create-react-class) isn't specified as a dependency, so an older version might be used in some projects. This might lead to an error similar to [this one](https://github.com/facebook/react/issues/12830). In our case, `UNSAFE_componentWilMount` was defined on `ScrollView` twice.